### PR TITLE
Add stress, precision support, compute

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.9]
-        torch-version: [1.10.0]
+        torch-version: [1.11.0]
         nequip-branch: ["main"]
 
     steps:
@@ -23,6 +23,8 @@ jobs:
         TORCH: "${{ matrix.torch-version }}"
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
+        sudo apt update
+        sudo apt install -y cmake
         python -m pip install --upgrade pip
         pip install torch==${TORCH} -f https://download.pytorch.org/whl/cpu/torch_stable.html
         pip install pytest
@@ -32,7 +34,6 @@ jobs:
         unzip -q libtorch-cxx11-abi-shared-with-deps-$TORCH+cpu.zip
     - name: Install MPI
       run: |
-        sudo apt update
         sudo apt install -y libopenmpi-dev --fix-missing
     - name: Install NequIP
       env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,9 +27,7 @@ jobs:
         sudo apt install -y cmake
         python -m pip install --upgrade pip
         pip install torch==${TORCH} -f https://download.pytorch.org/whl/cpu/torch_stable.html
-        pip install pytest
-        pip install pytest-xdist[psutil]
-        pip install mkl-include
+        pip install pytest mkl-include
         wget -q https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-$TORCH%2Bcpu.zip
         unzip -q libtorch-cxx11-abi-shared-with-deps-$TORCH+cpu.zip
     - name: Install MPI

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
         pip install pytest
         pip install pytest-xdist[psutil]
         pip install mkl-include
-        wget https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-$TORCH%2Bcpu.zip
+        wget -q https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-$TORCH%2Bcpu.zip
         unzip -q libtorch-cxx11-abi-shared-with-deps-$TORCH+cpu.zip
     - name: Install MPI
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,7 +53,7 @@ jobs:
         cd lammps_dir/lammps/
         mkdir build/
         cd build/
-        cmake ../cmake -DPKG_KOKKOS=ON -DKokkos_ENABLE_OPENMP=ON -DCMAKE_PREFIX_PATH=../../../libtorch -DMKL_INCLUDE_DIR=`python -c "import sysconfig;from pathlib import Path;print(Path(sysconfig.get_paths()[\"include\"]).parent)"`
+        cmake ../cmake -DCMAKE_BUILD_TYPE=Release -DPKG_KOKKOS=ON -DKokkos_ENABLE_OPENMP=ON -DCMAKE_PREFIX_PATH=../../../libtorch -DMKL_INCLUDE_DIR=`python -c "import sysconfig;from pathlib import Path;print(Path(sysconfig.get_paths()[\"include\"]).parent)"`
         make -j$(nproc)
         echo "LAMMPS in dir"
         pwd

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
       run: |
         mkdir lammps_dir/
         cd lammps_dir/
-        git clone -b stable_29Sep2021_update2 --depth 1 "https://github.com/lammps/lammps"
+        git clone --depth 1 "https://github.com/lammps/lammps"
         cd ..
         ./patch_lammps.sh lammps_dir/lammps/
         cd lammps_dir/lammps/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
         cd lammps_dir/lammps/
         mkdir build/
         cd build/
-        cmake ../cmake -DCMAKE_PREFIX_PATH=`python -c 'import torch;print(torch.utils.cmake_prefix_path)'` -DMKL_INCLUDE_DIR=`python -c "import sysconfig;from pathlib import Path;print(Path(sysconfig.get_paths()[\"include\"]).parent)"`
+        cmake ../cmake -DPKG_KOKKOS=ON -DKokkos_ENABLE_OPENMP=ON -DCMAKE_PREFIX_PATH=`python -c 'import torch;print(torch.utils.cmake_prefix_path)'` -DMKL_INCLUDE_DIR=`python -c "import sysconfig;from pathlib import Path;print(Path(sysconfig.get_paths()[\"include\"]).parent)"`
         make -j$(nproc)
         echo "LAMMPS in dir"
         pwd

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,8 @@ jobs:
         pip install pytest
         pip install pytest-xdist[psutil]
         pip install mkl-include
+        wget https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-$TORCH%2Bcpu.zip
+        unzip -q libtorch-cxx11-abi-shared-with-deps-$TORCH+cpu.zip
     - name: Install MPI
       run: |
         sudo apt update
@@ -52,7 +54,7 @@ jobs:
         cd lammps_dir/lammps/
         mkdir build/
         cd build/
-        cmake ../cmake -DPKG_KOKKOS=ON -DKokkos_ENABLE_OPENMP=ON -DCMAKE_PREFIX_PATH=`python -c 'import torch;print(torch.utils.cmake_prefix_path)'` -DMKL_INCLUDE_DIR=`python -c "import sysconfig;from pathlib import Path;print(Path(sysconfig.get_paths()[\"include\"]).parent)"`
+        cmake ../cmake -DPKG_KOKKOS=ON -DKokkos_ENABLE_OPENMP=ON -DCMAKE_PREFIX_PATH=../../../libtorch -DMKL_INCLUDE_DIR=`python -c "import sysconfig;from pathlib import Path;print(Path(sysconfig.get_paths()[\"include\"]).parent)"`
         make -j$(nproc)
         echo "LAMMPS in dir"
         pwd

--- a/.gitignore
+++ b/.gitignore
@@ -32,8 +32,6 @@
 *.out
 *.app
 
-.vscode
-
 
 
 # ---------- Python .gigignores-----------

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "editor.formatOnSave": false,
+    "[python]": {
+        "editor.formatOnSave": true
+    },
+    "python.formatting.provider": "black"
+}

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ pair_coeff	* * deployed.pth <Allegro type name for LAMMPS type 1> <Allegro type 
 ```
 where `deployed.pth` is the filename of your trained, **deployed** model.
 
-The names after the model path `deployed.pth` indicate, in order, the names of the Allegro model's atom types to use for LAMMPS atom types 1, 2, and so on. The number of names given must be equal to the number of atom types in the LAMMPS configuration (not the Allegro model!). 
+The names after the model path `deployed.pth` indicate, in order, the names of the Allegro model's atom types to use for LAMMPS atom types 1, 2, and so on. The number of names given must be equal to the number of atom types in the LAMMPS configuration (not the Allegro model!).
 The given names must be consistent with the names specified in the Allegro training YAML in `chemical_symbol_to_type` or `type_names`.
 
 To run with Kokkos, please see the [LAMMPS Kokkos documentation](https://docs.lammps.org/Speed_kokkos.html#running-on-gpus). Example:
@@ -35,7 +35,7 @@ to run on 2 nodes with 4 GPUs each.
 
 ### Download LAMMPS
 ```bash
-git clone -b stable_29Sep2021_update2 --depth 1 git@github.com:lammps/lammps
+git clone --depth 1 https://github.com/lammps/lammps
 ```
 or your preferred method.
 (`--depth 1` prevents the entire history of the LAMMPS repository from being downloaded.)
@@ -61,7 +61,7 @@ mkdir build
 cd build
 cmake ../cmake -DCMAKE_PREFIX_PATH=`python -c 'import torch;print(torch.utils.cmake_prefix_path)'`
 ```
-If you don't have PyTorch installed **OR** are using Kokkos, you need to download LibTorch from the [PyTorch download page](https://pytorch.org/get-started/locally/). **Ensure you download the cxx11 ABI version.** Unzip the downloaded file, then configure LAMMPS:
+If you don't have PyTorch installed **OR** are using Kokkos, you need to download LibTorch from the [PyTorch download page](https://pytorch.org/get-started/locally/). **Ensure you download the cxx11 ABI version if using Kokkos.** Unzip the downloaded file, then configure LAMMPS:
 ```bash
 cd lammps
 mkdir build
@@ -94,7 +94,7 @@ Note that the CUDA that comes with PyTorch when installed with `conda` (the `cud
 ```
 -DPKG_KOKKOS=ON -DKokkos_ENABLE_CUDA=ON
 ```
-to your `cmake` command.
+to your `cmake` command. See the [LAMMPS documentation][https://docs.lammps.org/Speed_kokkos.html] for more build options and how to correctly run LAMMPS with Kokkos.
 
 ### Building LAMMPS
 ```bash

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For more details on Allegro itself, background, and the LAMMPS pair style please
 
 ```
 pair_style	allegro
-pair_coeff	* * deployed.pth <type name 1> <type name 2> ...
+pair_coeff	* * deployed.pth <Allegro type name for LAMMPS type 1> <Allegro type name for LAMMPS type 2> ...
 ```
 where `deployed.pth` is the filename of your trained model.
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,10 @@
 
 This pair style allows you to use Allegro models from the [`allegro`](https://github.com/mir-group/allegro) package in LAMMPS simulations. Allegro is designed to enable parallelism, and so `pair_allegro` **supports MPI in LAMMPS**. It also supports OpenMP (better performance) or Kokkos (best performance) for accelerating the pair style.
 
-For more details on Allegro itself, background, and the LAMMPS pair style please see the [`allegro`](https://github.com/mir-group/allegro) package and our pre-print:
+For more details on Allegro itself, background, and the LAMMPS pair style please see the [`allegro`](https://github.com/mir-group/allegro) package and our paper:
 > *Learning Local Equivariant Representations for Large-Scale Atomistic Dynamics* <br/>
 > Albert Musaelian, Simon Batzner, Anders Johansson, Lixin Sun, Cameron J. Owen, Mordechai Kornbluth, Boris Kozinsky <br/>
-> https://arxiv.org/abs/2204.05249 <br/>
-> https://doi.org/10.48550/arXiv.2204.05249
+> https://www.nature.com/articles/s41467-023-36329-y <br/>
 
 `pair_allegro` authors: **Anders Johansson**, Albert Musaelian.
 
@@ -47,11 +46,12 @@ git clone git@github.com:mir-group/pair_allegro
 or by downloading a ZIP of the source.
 
 ### Patch LAMMPS
-#### Automatically
 From the `pair_allegro` directory, run:
 ```bash
 ./patch_lammps.sh /path/to/lammps/
 ```
+
+### Libraries
 
 #### Libtorch
 If you have PyTorch installed and are **NOT** using Kokkos:
@@ -86,7 +86,7 @@ CMake will look for CUDA and cuDNN. You may have to explicitly provide the path 
 Note that the CUDA that comes with PyTorch when installed with `conda` (the `cudatoolkit` package) is usually insufficient (see [here](https://github.com/pytorch/extension-cpp/issues/26), for example) and you may have to install full CUDA seperately. A minor version mismatch between the available full CUDA version and the version of `cudatoolkit` is usually *not* a problem, as long as the system CUDA is equal or newer. (For example, PyTorch's requested `cudatoolkit==11.3` with a system CUDA of 11.4 works, but a system CUDA 11.1 will likely fail.) cuDNN is also required by PyTorch.
 
 #### With OpenMP (optional, better performance)
-`pair_allegro` supports the use of OpenMP to accelerate certain parts of the pair style.
+`pair_allegro` supports the use of OpenMP to accelerate certain parts of the pair style, by setting `OMP_NUM_THREADS` and using the [LAMMPS OpenMP package](https://docs.lammps.org/Speed_omp.html).
 
 #### With Kokkos (GPU, optional, best performance)
 `pair_allegro` supports the use of Kokkos to accelerate certain parts of the pair style on the GPU to avoid host-GPU transfers.
@@ -106,7 +106,7 @@ This gives `lammps/build/lmp`, which can be run as usual with `/path/to/lmp -in 
 
 1. Q: My simulation is immediately or bizzarely unstable
 
-   A: Please ensure that your mapping from LAMMPS atom types to NequIP atom types, specified in the `pair_coeff` line, is correct.
+   A: Please ensure that your mapping from LAMMPS atom types to NequIP atom types, specified in the `pair_coeff` line, is correct, and that the units are consistent between your training data and your LAMMPS simulation.
 2. Q: I get the following error:
    ```
     instance of 'c10::Error'
@@ -114,6 +114,3 @@ This gives `lammps/build/lmp`, which can be run as usual with `/path/to/lmp -in 
    ```
 
    A: Make sure you remembered to deploy (compile) your model using `nequip-deploy`, and that the path to the model given with `pair_coeff` points to a deployed model `.pth` file, **not** a file containing only weights like `best_model.pth`.
-3. Q: The output pressures and stresses seem wrong / my NPT simulation is broken
-
-    A: NPT/stress support in LAMMPS for `pair_allegro` is in-progress and not yet available.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ or your preferred method.
 
 ### Download this repository
 ```bash
-git clone git@github.com:mir-group/pair_allegro
+git clone https://github.com/mir-group/pair_allegro
 ```
 or by downloading a ZIP of the source.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ For more details on Allegro itself, background, and the LAMMPS pair style please
 and
 > *Scaling the leading accuracy of deep equivariant models to biomolecular simulations of realistic size* <br/>
 > Albert Musaelian, Anders Johansson, Simon Batzner, Boris Kozinsky <br/>
-> https://arxiv.org/abs/2304.10061 <br/>
+> https://doi.org/10.1145/3581784.3627041 <br/>
 
 `pair_allegro` authors: **Anders Johansson**, Albert Musaelian.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ pair_coeff	* * deployed.pth <Allegro type name for LAMMPS type 1> <Allegro type 
 where `deployed.pth` is the filename of your trained, **deployed** model.
 
 The names after the model path `deployed.pth` indicate, in order, the names of the Allegro model's atom types to use for LAMMPS atom types 1, 2, and so on. The number of names given must be equal to the number of atom types in the LAMMPS configuration (not the Allegro model!).
-The given names must be consistent with the names specified in the Allegro training YAML in `chemical_symbol_to_type` or `type_names`.
+The given names must be consistent with the names specified in the Allegro training YAML in `chemical_symbol_to_type` or `type_names`. Typically, this will be the chemical symbol for each LAMMPS type.
 
 To run with Kokkos, please see the [LAMMPS Kokkos documentation](https://docs.lammps.org/Speed_kokkos.html#running-on-gpus). Example:
 ```bash
@@ -94,7 +94,7 @@ Note that the CUDA that comes with PyTorch when installed with `conda` (the `cud
 ```
 -DPKG_KOKKOS=ON -DKokkos_ENABLE_CUDA=ON
 ```
-to your `cmake` command. See the [LAMMPS documentation][https://docs.lammps.org/Speed_kokkos.html] for more build options and how to correctly run LAMMPS with Kokkos.
+to your `cmake` command. See the [LAMMPS documentation](https://docs.lammps.org/Speed_kokkos.html) for more build options and how to correctly run LAMMPS with Kokkos.
 
 ### Building LAMMPS
 ```bash

--- a/README.md
+++ b/README.md
@@ -6,12 +6,16 @@ For more details on Allegro itself, background, and the LAMMPS pair style please
 > *Learning Local Equivariant Representations for Large-Scale Atomistic Dynamics* <br/>
 > Albert Musaelian, Simon Batzner, Anders Johansson, Lixin Sun, Cameron J. Owen, Mordechai Kornbluth, Boris Kozinsky <br/>
 > https://www.nature.com/articles/s41467-023-36329-y <br/>
+and
+> *Scaling the leading accuracy of deep equivariant models to biomolecular simulations of realistic size* <br/>
+> Albert Musaelian, Anders Johansson, Simon Batzner, Boris Kozinsky <br/>
+> https://arxiv.org/abs/2304.10061 <br/>
 
 `pair_allegro` authors: **Anders Johansson**, Albert Musaelian.
 
 ## Pre-requisites
 
-* PyTorch or LibTorch >= 1.10.0
+* PyTorch or LibTorch >= 1.11.0;  please note that at present we **only recommend 1.11** on CUDA systems.
 
 ## Usage in LAMMPS
 
@@ -114,3 +118,10 @@ This gives `lammps/build/lmp`, which can be run as usual with `/path/to/lmp -in 
    ```
 
    A: Make sure you remembered to deploy (compile) your model using `nequip-deploy`, and that the path to the model given with `pair_coeff` points to a deployed model `.pth` file, **not** a file containing only weights like `best_model.pth`.
+3. Q: I get the following error:
+   ```
+    instance of 'c10::Error'
+        what():  isTuple()INTERNAL ASSERT FAILED 
+   ```
+
+   A: We've seen this error occur when you try to load a TorchScript model deployed from PyTorch>1.11 in LAMMPS built against 1.11. Try redeploying your model (retraining not necessary) in a PyTorch 1.11 install.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For more details on Allegro itself, background, and the LAMMPS pair style please
 pair_style	allegro
 pair_coeff	* * deployed.pth <Allegro type name for LAMMPS type 1> <Allegro type name for LAMMPS type 2> ...
 ```
-where `deployed.pth` is the filename of your trained model.
+where `deployed.pth` is the filename of your trained, **deployed** model.
 
 The names after the model path `deployed.pth` indicate, in order, the names of the Allegro model's atom types to use for LAMMPS atom types 1, 2, and so on. The number of names given must be equal to the number of atom types in the LAMMPS configuration (not the Allegro model!). 
 The given names must be consistent with the names specified in the Allegro training YAML in `chemical_symbol_to_type` or `type_names`.
@@ -101,3 +101,19 @@ to your `cmake` command.
 make -j$(nproc)
 ```
 This gives `lammps/build/lmp`, which can be run as usual with `/path/to/lmp -in in.script`. If you specify `-DCMAKE_INSTALL_PREFIX=/somewhere/in/$PATH` (the default is `$HOME/.local`), you can do `make install` and just run `lmp -in in.script`.
+
+## FAQ
+
+1. Q: My simulation is immediately or bizzarely unstable
+
+   A: Please ensure that your mapping from LAMMPS atom types to NequIP atom types, specified in the `pair_coeff` line, is correct.
+2. Q: I get the following error:
+   ```
+    instance of 'c10::Error'
+        what():  PytorchStreamReader failed locating file constants.pkl: file not found
+   ```
+
+   A: Make sure you remembered to deploy (compile) your model using `nequip-deploy`, and that the path to the model given with `pair_coeff` points to a deployed model `.pth` file, **not** a file containing only weights like `best_model.pth`.
+3. Q: The output pressures and stresses seem wrong / my NPT simulation is broken
+
+    A: NPT/stress support in LAMMPS for `pair_allegro` is in-progress and not yet available.

--- a/compute_allegro.cpp
+++ b/compute_allegro.cpp
@@ -78,6 +78,12 @@ void ComputeAllegro::compute_vector()
 {
   invoked_peratom = update->ntimestep;
 
+  // printf("extracting %s\n", quantity.c_str()); fflush(stdout);
+  // printf("keys:");
+  // for (auto const& [key,val] : ((PairAllegro<lowhigh> *) force->pair)->custom_output) {
+  //   printf(" %s", key.data());
+  // }
+  // printf("\n"); fflush(stdout);
   const torch::Tensor &quantity_tensor =
       ((PairAllegro<lowhigh> *) force->pair)->custom_output.at(quantity).cpu().ravel();
 

--- a/compute_allegro.cpp
+++ b/compute_allegro.cpp
@@ -77,5 +77,7 @@ void ComputeAllegro::compute_vector(){
   for(int i = 0; i < size_vector; i++){
     vector[i] = quantity[i];
   }
+
+  MPI_Allreduce(MPI_IN_PLACE, vector, size_vector, MPI_DOUBLE, MPI_SUM, world);
 }
 

--- a/compute_allegro.cpp
+++ b/compute_allegro.cpp
@@ -55,6 +55,12 @@ ComputeAllegro::ComputeAllegro(LAMMPS *lmp, int narg, char **arg) : Compute(lmp,
   if(size_vector<=0)
     error->all(FLERR, "Incorrect vector length!");
   memory->create(vector, size_vector, "ComputeAllegro:vector");
+
+  if (force->pair == nullptr) {
+    error->all(FLERR, "no pair style; compute allegro must be defined after pair style");
+  }
+
+  ((PairAllegro<lowhigh>*) force->pair)->add_custom_output(quantity);
 }
 
 void ComputeAllegro::init(){

--- a/compute_allegro.cpp
+++ b/compute_allegro.cpp
@@ -1,0 +1,81 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   https://lammps.sandia.gov/, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Contributing author: Anders Johansson (Harvard)
+------------------------------------------------------------------------- */
+
+#include "compute_allegro.h"
+#include "pair_allegro.h"
+#include "atom.h"
+#include "comm.h"
+#include "error.h"
+#include "force.h"
+#include "memory.h"
+#include "update.h"
+
+#include <cmath>
+#include <cstring>
+#include <numeric>
+#include <cassert>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <torch/torch.h>
+#include <torch/script.h>
+
+
+using namespace LAMMPS_NS;
+
+ComputeAllegro::ComputeAllegro(LAMMPS *lmp, int narg, char **arg) : Compute(lmp, narg, arg) {
+
+  // compute 1 all allegro quantity length
+  if (narg != 5)
+    error->all(FLERR, "Incorrect args for compute nequip");
+
+  if (strcmp(arg[1], "all") != 0)
+    error->all(FLERR, "compute nequip can only operate on group 'all'");
+
+  quantity = arg[3];
+  vector_flag = 1;
+  size_vector = std::atoi(arg[4]);
+
+  if (comm->me==0) error->message(FLERR, "compute allegro will evaluate the quantity {} of length {}", quantity, size_vector);
+
+  if(size_vector<=0)
+    error->all(FLERR, "Incorrect vector length!");
+  memory->create(vector, size_vector, "ComputeAllegro:vector");
+}
+
+void ComputeAllegro::init(){
+  ;
+}
+
+ComputeAllegro::~ComputeAllegro(){
+  if (!copymode) {
+    memory->destroy(vector);
+  }
+}
+
+// Force and energy computation
+void ComputeAllegro::compute_vector(){
+  invoked_peratom = update->ntimestep;
+
+  const torch::Tensor &quantity_tensor = ((PairAllegro<lowhigh>*) force->pair)->custom_output.at(quantity).cpu();
+  auto quantity = quantity_tensor.data_ptr<double>();
+
+  for(int i = 0; i < size_vector; i++){
+    vector[i] = quantity[i];
+  }
+}
+

--- a/compute_allegro.cpp
+++ b/compute_allegro.cpp
@@ -16,32 +16,31 @@
 ------------------------------------------------------------------------- */
 
 #include "compute_allegro.h"
-#include "pair_allegro.h"
 #include "atom.h"
 #include "comm.h"
 #include "error.h"
 #include "force.h"
 #include "memory.h"
+#include "pair_allegro.h"
 #include "update.h"
 
+#include <cassert>
 #include <cmath>
 #include <cstring>
-#include <numeric>
-#include <cassert>
 #include <iostream>
+#include <numeric>
 #include <sstream>
 #include <string>
-#include <torch/torch.h>
 #include <torch/script.h>
-
+#include <torch/torch.h>
 
 using namespace LAMMPS_NS;
 
-ComputeAllegro::ComputeAllegro(LAMMPS *lmp, int narg, char **arg) : Compute(lmp, narg, arg) {
+ComputeAllegro::ComputeAllegro(LAMMPS *lmp, int narg, char **arg) : Compute(lmp, narg, arg)
+{
 
   // compute 1 all allegro quantity length
-  if (narg != 5)
-    error->all(FLERR, "Incorrect args for compute nequip");
+  if (narg != 5) error->all(FLERR, "Incorrect args for compute nequip");
 
   if (strcmp(arg[1], "all") != 0)
     error->all(FLERR, "compute nequip can only operate on group 'all'");
@@ -50,40 +49,46 @@ ComputeAllegro::ComputeAllegro(LAMMPS *lmp, int narg, char **arg) : Compute(lmp,
   vector_flag = 1;
   size_vector = std::atoi(arg[4]);
 
-  if (comm->me==0) error->message(FLERR, "compute allegro will evaluate the quantity {} of length {}", quantity, size_vector);
+  if (comm->me == 0)
+    error->message(FLERR, "compute allegro will evaluate the quantity {} of length {}", quantity,
+                   size_vector);
 
-  if(size_vector<=0)
-    error->all(FLERR, "Incorrect vector length!");
+  if (size_vector <= 0) error->all(FLERR, "Incorrect vector length!");
   memory->create(vector, size_vector, "ComputeAllegro:vector");
 
   if (force->pair == nullptr) {
     error->all(FLERR, "no pair style; compute allegro must be defined after pair style");
   }
 
-  ((PairAllegro<lowhigh>*) force->pair)->add_custom_output(quantity);
+  ((PairAllegro<lowhigh> *) force->pair)->add_custom_output(quantity);
 }
 
-void ComputeAllegro::init(){
+void ComputeAllegro::init()
+{
   ;
 }
 
-ComputeAllegro::~ComputeAllegro(){
-  if (!copymode) {
-    memory->destroy(vector);
-  }
+ComputeAllegro::~ComputeAllegro()
+{
+  if (!copymode) { memory->destroy(vector); }
 }
 
 // Force and energy computation
-void ComputeAllegro::compute_vector(){
+void ComputeAllegro::compute_vector()
+{
   invoked_peratom = update->ntimestep;
 
-  const torch::Tensor &quantity_tensor = ((PairAllegro<lowhigh>*) force->pair)->custom_output.at(quantity).cpu();
+  const torch::Tensor &quantity_tensor =
+      ((PairAllegro<lowhigh> *) force->pair)->custom_output.at(quantity).cpu().ravel();
+
   auto quantity = quantity_tensor.data_ptr<double>();
 
-  for(int i = 0; i < size_vector; i++){
-    vector[i] = quantity[i];
+  if (quantity_tensor.size(0) != size_vector) {
+    error->one(FLERR, "size {} of quantity tensor {} does not match expected {} on rank {}",
+               quantity_tensor.size(0), this->quantity, size_vector, comm->me);
   }
+
+  for (int i = 0; i < size_vector; i++) { vector[i] = quantity[i]; }
 
   MPI_Allreduce(MPI_IN_PLACE, vector, size_vector, MPI_DOUBLE, MPI_SUM, world);
 }
-

--- a/compute_allegro.h
+++ b/compute_allegro.h
@@ -1,0 +1,47 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+#ifdef COMPUTE_CLASS
+
+ComputeStyle(allegro,ComputeAllegro)
+
+#else
+
+#ifndef LMP_COMPUTE_ALLEGRO_H
+#define LMP_COMPUTE_ALLEGRO_H
+
+#include "compute.h"
+#include "pair_allegro.h"
+
+#include <torch/torch.h>
+#include <string>
+
+namespace LAMMPS_NS {
+
+class ComputeAllegro : public Compute {
+ public:
+  ComputeAllegro(class LAMMPS *, int, char**);
+  ~ComputeAllegro();
+  void compute_vector() override;
+  void init() override;
+
+ protected:
+  std::string quantity;
+
+};
+
+}
+
+#endif
+#endif
+

--- a/compute_allegro.h
+++ b/compute_allegro.h
@@ -13,7 +13,8 @@
 
 #ifdef COMPUTE_CLASS
 
-ComputeStyle(allegro,ComputeAllegro)
+ComputeStyle(allegro,ComputeAllegro<0>)
+ComputeStyle(allegro/atom,ComputeAllegro<1>)
 
 #else
 
@@ -23,20 +24,28 @@ ComputeStyle(allegro,ComputeAllegro)
 #include "compute.h"
 #include "pair_allegro.h"
 
-#include <torch/torch.h>
 #include <string>
 
 namespace LAMMPS_NS {
 
+template<int peratom>
 class ComputeAllegro : public Compute {
  public:
   ComputeAllegro(class LAMMPS *, int, char**);
   ~ComputeAllegro();
   void compute_vector() override;
+  void compute_peratom() override;
   void init() override;
+
+  int pack_reverse_comm(int, int, double *) override;
+  void unpack_reverse_comm(int, int *, double *) override;
 
  protected:
   std::string quantity;
+  double *quantityptr;
+  int newton;
+  int nperatom;
+  int nmax;
 
 };
 

--- a/pair_allegro.cpp
+++ b/pair_allegro.cpp
@@ -495,7 +495,8 @@ template <Precision precision> void PairAllegro<precision>::compute(int eflag, i
   }
   if (vflag_atom) { error->all(FLERR, "Pair style Allegro does not support per-atom virial"); }
 
-  if (update->ntimestep == this->output->next) {
+  // TODO: Figure out reliable solution
+  // if (update->ntimestep == this->output->next || update->ntimestep==0) {
     if (debug_mode) {
       std::cout << "ALLEGRO CUSTOM OUTPUT" << std::endl;
       for (const auto &elem : output) {
@@ -505,9 +506,10 @@ template <Precision precision> void PairAllegro<precision>::compute(int eflag, i
 
     for (const std::string &output_name : custom_output_names) {
       if (!output.contains(output_name)) error->all(FLERR, "missing {}", output_name);
-      custom_output.insert_or_assign(output_name, output.at(output_name).toTensor());
+      // printf("pair_allegro inserting %s\n", output_name.data()); fflush(stdout);
+      custom_output.insert_or_assign(output_name, output.at(output_name).toTensor().detach());
     }
-  }
+  // }
 }
 
 template <Precision precision> void PairAllegro<precision>::add_custom_output(std::string name)

--- a/pair_allegro.cpp
+++ b/pair_allegro.cpp
@@ -335,6 +335,9 @@ template <Precision precision> void PairAllegro<precision>::compute(int eflag, i
   // Neighbor list per atom
   int **firstneigh = list->firstneigh;
 
+  // Skip calculation if empty domain
+  if (inum==0) return;
+
   // Total number of bonds (sum of number of neighbors)
   int nedges = 0;
 

--- a/pair_allegro.cpp
+++ b/pair_allegro.cpp
@@ -470,7 +470,7 @@ void PairAllegro<precision>::compute(int eflag, int vflag){
 
   if(vflag){
     torch::Tensor v_tensor = output.at("virial").toTensor().cpu();
-    auto v = v_tensor.accessor<float, 3>();
+    auto v = v_tensor.accessor<outputtype, 3>();
     // Convert from 3x3 symmetric tensor format, which NequIP outputs, to the flattened form LAMMPS expects
     // First [0] index on v is batch
     virial[0] = v[0][0][0];

--- a/pair_allegro.cpp
+++ b/pair_allegro.cpp
@@ -491,6 +491,15 @@ void PairAllegro<precision>::compute(int eflag, int vflag){
   if(vflag_atom) {
     error->all(FLERR,"Pair style Allegro does not support per-atom virial");
   }
+
+  for(const std::string &output_name : custom_output_names){
+    custom_output.insert_or_assign(output_name, output.at(output_name).toTensor());
+  }
+}
+
+template<Precision precision>
+void PairAllegro<precision>::add_custom_output(std::string name){
+  custom_output_names.push_back(name);
 }
 
 namespace LAMMPS_NS {

--- a/pair_allegro.cpp
+++ b/pair_allegro.cpp
@@ -492,6 +492,13 @@ void PairAllegro<precision>::compute(int eflag, int vflag){
     error->all(FLERR,"Pair style Allegro does not support per-atom virial");
   }
 
+  if (debug_mode) {
+    std::cout << "ALLEGRO CUSTOM OUTPUT" << std::endl;
+    for(const auto &elem : output){
+      std::cout << elem.key() << "\n" << elem.value() << std::endl;
+    }
+  }
+
   for(const std::string &output_name : custom_output_names){
     custom_output.insert_or_assign(output_name, output.at(output_name).toTensor());
   }

--- a/pair_allegro.cpp
+++ b/pair_allegro.cpp
@@ -109,7 +109,7 @@ PairAllegro<precision>::PairAllegro(LAMMPS *lmp) : Pair(lmp) {
   else {
     device = torch::kCPU;
   }
-  std::cout << "Allegro is using device " << device << "\n";
+  if (debug_mode) std::cout << "Allegro is using device " << device << "\n";
 }
 
 template<Precision precision>

--- a/pair_allegro.cpp
+++ b/pair_allegro.cpp
@@ -457,4 +457,20 @@ void PairAllegro::compute(int eflag, int vflag){
     if (eflag_atom && ii < inum) eatom[i] = atomic_energies[i][0];
     if(ii < inum) eng_vdwl += atomic_energies[i][0];
   }
+
+  if(vflag){
+    torch::Tensor v_tensor = output.at("virial").toTensor().cpu();
+    auto v = v_tensor.accessor<float, 3>();
+    // Convert from 3x3 symmetric tensor format, which NequIP outputs, to the flattened form LAMMPS expects
+    // First [0] index on v is batch
+    virial[0] = v[0][0][0];
+    virial[1] = v[0][1][1];
+    virial[2] = v[0][2][2];
+    virial[3] = v[0][0][1];
+    virial[4] = v[0][0][2];
+    virial[5] = v[0][1][2];
+  }
+  if(vflag_atom) {
+    error->all(FLERR,"Pair style Allegro does not support per-atom virial");
+  }
 }

--- a/pair_allegro.cpp
+++ b/pair_allegro.cpp
@@ -15,7 +15,6 @@
    Contributing author: Anders Johansson (Harvard)
 ------------------------------------------------------------------------- */
 
-#include <pair_allegro.h>
 #include "atom.h"
 #include "comm.h"
 #include "domain.h"
@@ -25,81 +24,87 @@
 #include "neigh_list.h"
 #include "neigh_request.h"
 #include "neighbor.h"
+#include "output.h"
 #include "potential_file_reader.h"
 #include "tokenizer.h"
+#include "update.h"
+#include <pair_allegro.h>
 
 #include <algorithm>
-#include <vector>
+#include <cassert>
 #include <cmath>
 #include <cstring>
-#include <numeric>
-#include <cassert>
 #include <iostream>
+#include <numeric>
 #include <sstream>
 #include <string>
-#include <torch/torch.h>
-#include <torch/script.h>
 #include <torch/csrc/jit/runtime/graph_executor.h>
+#include <torch/script.h>
+#include <torch/torch.h>
+#include <vector>
 
 // TODO: Only if MPI is available
 #include <mpi.h>
 
-
 // Freezing is broken from C++ in <=1.10; so we've dropped support.
 #if (TORCH_VERSION_MAJOR == 1 && TORCH_VERSION_MINOR <= 10)
-  #error "PyTorch version < 1.11 is not supported"
+#error "PyTorch version < 1.11 is not supported"
 #endif
-
 
 using namespace LAMMPS_NS;
 
-template<Precision precision>
-PairAllegro<precision>::PairAllegro(LAMMPS *lmp) : Pair(lmp) {
+template <Precision precision> PairAllegro<precision>::PairAllegro(LAMMPS *lmp) : Pair(lmp)
+{
   restartinfo = 0;
   manybody_flag = 1;
 
-  if (comm->me==0) std::cout << "Allegro is using input precision " << typeid(inputtype).name() << " and output precision " << typeid(outputtype).name() << std::endl;;
+  if (comm->me == 0)
+    std::cout << "Allegro is using input precision " << typeid(inputtype).name()
+              << " and output precision " << typeid(outputtype).name() << std::endl;
+  ;
 
-  if(const char* env_p = std::getenv("ALLEGRO_DEBUG")){
+  if (const char *env_p = std::getenv("ALLEGRO_DEBUG")) {
     std::cout << "PairAllegro is in DEBUG mode, since ALLEGRO_DEBUG is in env\n";
     debug_mode = 1;
   }
 
-  if(torch::cuda::is_available()){
+  if (torch::cuda::is_available()) {
     int deviceidx = -1;
-    if(comm->nprocs > 1){
+    if (comm->nprocs > 1) {
       MPI_Comm shmcomm;
-      MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0,
-          MPI_INFO_NULL, &shmcomm);
+      MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &shmcomm);
       int shmrank;
       MPI_Comm_rank(shmcomm, &shmrank);
       deviceidx = shmrank;
     }
-    if(deviceidx >= 0) {
+    if (deviceidx >= 0) {
       int devicecount = torch::cuda::device_count();
-      if(deviceidx >= devicecount) {
-        if(debug_mode) {
+      if (deviceidx >= devicecount) {
+        if (debug_mode) {
           // To allow testing multi-rank calls, we need to support multiple ranks with one GPU
-          std::cerr << "WARNING (Allegro): my rank (" << deviceidx << ") is bigger than the number of visible devices (" << devicecount << "), wrapping around to use device " << deviceidx % devicecount << " again!!!";
+          std::cerr << "WARNING (Allegro): my rank (" << deviceidx
+                    << ") is bigger than the number of visible devices (" << devicecount
+                    << "), wrapping around to use device " << deviceidx % devicecount
+                    << " again!!!";
           deviceidx = deviceidx % devicecount;
-        }
-        else {
+        } else {
           // Otherwise, more ranks than GPUs is an error
-          std::cerr << "ERROR (Allegro): my rank (" << deviceidx << ") is bigger than the number of visible devices (" << devicecount << ")!!!";
-          error->all(FLERR,"pair_allegro: mismatch between number of ranks and number of available GPUs");
+          std::cerr << "ERROR (Allegro): my rank (" << deviceidx
+                    << ") is bigger than the number of visible devices (" << devicecount << ")!!!";
+          error->all(FLERR,
+                     "pair_allegro: mismatch between number of ranks and number of available GPUs");
         }
       }
     }
-    device = c10::Device(torch::kCUDA,deviceidx);
-  }
-  else {
+    device = c10::Device(torch::kCUDA, deviceidx);
+  } else {
     device = torch::kCPU;
   }
   if (debug_mode) std::cout << "Allegro is using device " << device << "\n";
 }
 
-template<Precision precision>
-PairAllegro<precision>::~PairAllegro(){
+template <Precision precision> PairAllegro<precision>::~PairAllegro()
+{
   if (copymode) return;
   if (allocated) {
     memory->destroy(setflag);
@@ -108,98 +113,90 @@ PairAllegro<precision>::~PairAllegro(){
   }
 }
 
-template<Precision precision>
-void PairAllegro<precision>::init_style(){
-  if (atom->tag_enable == 0)
-    error->all(FLERR,"Pair style Allegro requires atom IDs");
+template <Precision precision> void PairAllegro<precision>::init_style()
+{
+  if (atom->tag_enable == 0) error->all(FLERR, "Pair style Allegro requires atom IDs");
 
   // Request a full neighbor list.
   if (lmp->kokkos) {
     // Only request full to avoid a Kokkos bug; pair_allegro_kokkos.cpp doesn't need GHOST anyway
     neighbor->add_request(this, NeighConst::REQ_FULL);
-  }
-  else {
+  } else {
     // Non-kokkos needs ghost to avoid segfaults
-    neighbor->add_request(this, NeighConst::REQ_FULL|NeighConst::REQ_GHOST);
+    neighbor->add_request(this, NeighConst::REQ_FULL | NeighConst::REQ_GHOST);
   }
 
-  if (force->newton_pair == 0)
-    error->all(FLERR,"Pair style Allegro requires newton pair on");
+  if (force->newton_pair == 0) error->all(FLERR, "Pair style Allegro requires newton pair on");
 }
 
-template<Precision precision>
-double PairAllegro<precision>::init_one(int i, int j)
+template <Precision precision> double PairAllegro<precision>::init_one(int i, int j)
 {
   return cutoff;
 }
 
-template<Precision precision>
-void PairAllegro<precision>::allocate()
+template <Precision precision> void PairAllegro<precision>::allocate()
 {
   allocated = 1;
   int n = atom->ntypes;
 
-  memory->create(setflag,n+1,n+1,"pair:setflag");
-  memory->create(cutsq,n+1,n+1,"pair:cutsq");
-  memory->create(cutoff_matrix,n,n,"pair:cutoff_matrix");
+  memory->create(setflag, n + 1, n + 1, "pair:setflag");
+  memory->create(cutsq, n + 1, n + 1, "pair:cutsq");
+  memory->create(cutoff_matrix, n, n, "pair:cutoff_matrix");
 }
 
-template<Precision precision>
-void PairAllegro<precision>::settings(int narg, char ** /*arg*/) {
+template <Precision precision> void PairAllegro<precision>::settings(int narg, char ** /*arg*/)
+{
   // "allegro" should be the only word after "pair_style" in the input file.
-  if (narg > 0)
-    error->all(FLERR, "Illegal pair_style command, too many arguments");
+  if (narg > 0) error->all(FLERR, "Illegal pair_style command, too many arguments");
 }
 
-template<Precision precision>
-void PairAllegro<precision>::coeff(int narg, char **arg) {
-  if (!allocated)
-    allocate();
+template <Precision precision> void PairAllegro<precision>::coeff(int narg, char **arg)
+{
+  if (!allocated) allocate();
 
   int ntypes = atom->ntypes;
 
   // Should be exactly 3 arguments following "pair_coeff" in the input file.
-  if (narg != (3+ntypes))
-    error->all(FLERR, "Incorrect args for pair coefficients, should be * * <model>.pth <type1> <type2> ... <typen>");
+  if (narg != (3 + ntypes))
+    error->all(FLERR,
+               "Incorrect args for pair coefficients, should be * * <model>.pth <type1> <type2> "
+               "... <typen>");
 
   // Ensure I,J args are "* *".
   if (strcmp(arg[0], "*") != 0 || strcmp(arg[1], "*") != 0)
     error->all(FLERR, "Incorrect args for pair coefficients");
 
   for (int i = 1; i <= ntypes; i++)
-    for (int j = i; j <= ntypes; j++)
-      setflag[i][j] = 0;
+    for (int j = i; j <= ntypes; j++) setflag[i][j] = 0;
 
   std::vector<std::string> elements(ntypes);
-  for(int i = 0; i < ntypes; i++){
-    elements[i] = arg[i+1];
-  }
+  for (int i = 0; i < ntypes; i++) { elements[i] = arg[i + 1]; }
 
-  if (comm->me==0) std::cout << "Allegro: Loading model from " << arg[2] << "\n";
+  if (comm->me == 0) std::cout << "Allegro: Loading model from " << arg[2] << "\n";
 
-  std::unordered_map<std::string, std::string> metadata = {
-    {"config", ""},
-    {"nequip_version", ""},
-    {"r_max", ""},
-    {"n_species", ""},
-    {"type_names", ""},
-    {"_jit_bailout_depth", ""},
-    {"_jit_fusion_strategy", ""},
-    {"allow_tf32", ""},
-    {"per_edge_type_cutoff", ""}
-  };
+  std::unordered_map<std::string, std::string> metadata = {{"config", ""},
+                                                           {"nequip_version", ""},
+                                                           {"r_max", ""},
+                                                           {"n_species", ""},
+                                                           {"type_names", ""},
+                                                           {"_jit_bailout_depth", ""},
+                                                           {"_jit_fusion_strategy", ""},
+                                                           {"allow_tf32", ""},
+                                                           {"per_edge_type_cutoff", ""}};
   model = torch::jit::load(std::string(arg[2]), device, metadata);
   model.eval();
 
   // Check if model is a NequIP model
   if (metadata["nequip_version"].empty()) {
-    error->all(FLERR, "The indicated TorchScript file does not appear to be a deployed NequIP model; did you forget to run `nequip-deploy`?");
+    error->all(FLERR,
+               "The indicated TorchScript file does not appear to be a deployed NequIP model; did "
+               "you forget to run `nequip-deploy`?");
   }
 
   // If the model is not already frozen, we should freeze it:
   // This is the check used by PyTorch: https://github.com/pytorch/pytorch/blob/master/torch/csrc/jit/api/module.cpp#L476
   if (model.hasattr("training")) {
-    if (comm->me==0) std::cout << "Allegro: Freezing TorchScript model...\n";
+    if (comm->me == 0) std::cout << "Allegro: Freezing TorchScript model...\n";
     model = torch::jit::freeze(model);
   }
 
@@ -236,8 +233,9 @@ void PairAllegro<precision>::coeff(int narg, char **arg) {
 
   if (debug_mode) {
     std::cout << "Allegro: Information from model: " << metadata.size() << " key-value pairs\n";
-    for( const auto& n : metadata ) {
-      if(n.first == "type_names") std::cout << "Key:[" << n.first << "] Value:[" << n.second << "]\n";
+    for (const auto &n : metadata) {
+      if (n.first == "type_names")
+        std::cout << "Key:[" << n.first << "] Value:[" << n.second << "]\n";
     }
   }
 
@@ -248,15 +246,20 @@ void PairAllegro<precision>::coeff(int narg, char **arg) {
   std::stringstream ss;
   int n_species = std::stod(metadata["n_species"]);
   ss << metadata["type_names"];
-  if(comm->me==0) std::cout << "Type mapping:" << "\n";
-  if(comm->me==0) std::cout << "Allegro type | Allegro name | LAMMPS type | LAMMPS name" << "\n";
-  for (int i = 0; i < n_species; i++){
+  if (comm->me == 0)
+    std::cout << "Type mapping:"
+              << "\n";
+  if (comm->me == 0)
+    std::cout << "Allegro type | Allegro name | LAMMPS type | LAMMPS name"
+              << "\n";
+  for (int i = 0; i < n_species; i++) {
     std::string ele;
     ss >> ele;
-    for (int itype = 1; itype <= ntypes; itype++){
-      if (ele.compare(arg[itype + 3 - 1]) == 0){
-        type_mapper[itype-1] = i;
-        if(comm->me==0) std::cout << i << " | " << ele << " | " << itype << " | " << arg[itype + 3 - 1] << "\n";
+    for (int itype = 1; itype <= ntypes; itype++) {
+      if (ele.compare(arg[itype + 3 - 1]) == 0) {
+        type_mapper[itype - 1] = i;
+        if (comm->me == 0)
+          std::cout << i << " | " << ele << " | " << itype << " | " << arg[itype + 3 - 1] << "\n";
       }
     }
   }
@@ -264,9 +267,7 @@ void PairAllegro<precision>::coeff(int narg, char **arg) {
   // set setflag i,j for type pairs where both are mapped to elements
   for (int i = 1; i <= ntypes; i++) {
     for (int j = i; j <= ntypes; j++) {
-        if ((type_mapper[i-1] >= 0) && (type_mapper[j-1] >= 0)) {
-            setflag[i][j] = 1;
-        }
+      if ((type_mapper[i - 1] >= 0) && (type_mapper[j - 1] >= 0)) { setflag[i][j] = 1; }
     }
   }
 
@@ -275,41 +276,32 @@ void PairAllegro<precision>::coeff(int narg, char **arg) {
     matrix_string << metadata["per_edge_type_cutoff"];
     std::vector<int> reverse_type_mapper(n_species, -1);
 
-    for(int i = 0; i < ntypes; i++){
-      reverse_type_mapper[type_mapper[i]] = i;
-    }
+    for (int i = 0; i < ntypes; i++) { reverse_type_mapper[type_mapper[i]] = i; }
 
-    for(int i = 0; i < n_species; i++){
-      for(int j = 0; j < n_species; j++){
+    for (int i = 0; i < n_species; i++) {
+      for (int j = 0; j < n_species; j++) {
         double cutij;
         matrix_string >> cutij;
-        if (reverse_type_mapper[i]>=0 && reverse_type_mapper[j]>=0){
-          if(comm->me==0) {
-            printf("%s %s si=%d sj=%d ti=%d tj=%d cut=%.2f\n",
-                arg[reverse_type_mapper[i]+3],
-                arg[reverse_type_mapper[j]+3],
-                i, j,
-                reverse_type_mapper[i],
-                reverse_type_mapper[j],
-                cutij);
+        if (reverse_type_mapper[i] >= 0 && reverse_type_mapper[j] >= 0) {
+          if (comm->me == 0) {
+            printf("%s %s si=%d sj=%d ti=%d tj=%d cut=%.2f\n", arg[reverse_type_mapper[i] + 3],
+                   arg[reverse_type_mapper[j] + 3], i, j, reverse_type_mapper[i],
+                   reverse_type_mapper[j], cutij);
           }
-          cutoff_matrix[reverse_type_mapper[i]][reverse_type_mapper[j]] = cutij; //TODO
+          cutoff_matrix[reverse_type_mapper[i]][reverse_type_mapper[j]] = cutij;    //TODO
         }
       }
     }
   } else {
-    for(int i = 0; i < ntypes; i++){
-      for(int j = 0; j < ntypes; j++){
-        cutoff_matrix[i][j] = cutoff;
-      }
+    for (int i = 0; i < ntypes; i++) {
+      for (int j = 0; j < ntypes; j++) { cutoff_matrix[i][j] = cutoff; }
     }
   }
-
 }
 
 // Force and energy computation
-template<Precision precision>
-void PairAllegro<precision>::compute(int eflag, int vflag){
+template <Precision precision> void PairAllegro<precision>::compute(int eflag, int vflag)
+{
   ev_init(eflag, vflag);
 
   // Get info from lammps:
@@ -331,7 +323,7 @@ void PairAllegro<precision>::compute(int eflag, int vflag){
 
   // Number of local/real atoms
   int inum = list->inum;
-  assert(inum==nlocal); // This should be true, if my understanding is correct
+  assert(inum == nlocal);    // This should be true, if my understanding is correct
   // Number of ghost atoms
   int nghost = list->gnum;
   // Total number of atoms
@@ -343,7 +335,6 @@ void PairAllegro<precision>::compute(int eflag, int vflag){
   // Neighbor list per atom
   int **firstneigh = list->firstneigh;
 
-
   // Total number of bonds (sum of number of neighbors)
   int nedges = 0;
 
@@ -351,13 +342,13 @@ void PairAllegro<precision>::compute(int eflag, int vflag){
   std::vector<int> neigh_per_atom(nlocal, 0);
   int ntypes = atom->ntypes;
 
-#pragma omp parallel for reduction(+:nedges)
-  for(int ii = 0; ii < nlocal; ii++){
+#pragma omp parallel for reduction(+ : nedges)
+  for (int ii = 0; ii < nlocal; ii++) {
     int i = ilist[ii];
 
     int jnum = numneigh[i];
     int *jlist = firstneigh[i];
-    for(int jj = 0; jj < jnum; jj++){
+    for (int jj = 0; jj < jnum; jj++) {
       int j = jlist[jj];
       j &= NEIGHMASK;
 
@@ -365,11 +356,13 @@ void PairAllegro<precision>::compute(int eflag, int vflag){
       double dy = x[i][1] - x[j][1];
       double dz = x[i][2] - x[j][2];
 
-      double rsq = dx*dx + dy*dy + dz*dz;
+      double rsq = dx * dx + dy * dy + dz * dz;
 
-      double cutij = cutoff_matrix[type[i]-1][type[j]-1];// cutoff_matrix[(type[i]-1)*ntypes + type[j]-1];
+      double cutij =
+          cutoff_matrix[type[i] - 1]
+                       [type[j] - 1];    // cutoff_matrix[(type[i]-1)*ntypes + type[j]-1];
       //printf("i=%5d j=%5d ti=%d tj=%d cut=%.2f\n", i, j, type[i], type[j], cutij);
-      if(rsq <= cutij*cutij) {
+      if (rsq <= cutij * cutij) {
         neigh_per_atom[ii]++;
         nedges++;
       }
@@ -379,18 +372,20 @@ void PairAllegro<precision>::compute(int eflag, int vflag){
   // Cumulative sum of neighbors, for knowing where to fill in the edges tensor
   std::vector<int> cumsum_neigh_per_atom(nlocal);
 
-  for(int ii = 1; ii < nlocal; ii++){
-    cumsum_neigh_per_atom[ii] = cumsum_neigh_per_atom[ii-1] + neigh_per_atom[ii-1];
+  for (int ii = 1; ii < nlocal; ii++) {
+    cumsum_neigh_per_atom[ii] = cumsum_neigh_per_atom[ii - 1] + neigh_per_atom[ii - 1];
   }
 
-  torch::Tensor pos_tensor = torch::zeros({ntotal, 3}, torch::TensorOptions().dtype(inputtorchtype));
-  torch::Tensor edges_tensor = torch::zeros({2,nedges}, torch::TensorOptions().dtype(torch::kInt64));
-  torch::Tensor ij2type_tensor = torch::zeros({ntotal}, torch::TensorOptions().dtype(torch::kInt64));
+  torch::Tensor pos_tensor =
+      torch::zeros({ntotal, 3}, torch::TensorOptions().dtype(inputtorchtype));
+  torch::Tensor edges_tensor =
+      torch::zeros({2, nedges}, torch::TensorOptions().dtype(torch::kInt64));
+  torch::Tensor ij2type_tensor =
+      torch::zeros({ntotal}, torch::TensorOptions().dtype(torch::kInt64));
 
   auto pos = pos_tensor.accessor<inputtype, 2>();
   auto edges = edges_tensor.accessor<long, 2>();
   auto ij2type = ij2type_tensor.accessor<long, 1>();
-
 
   // Loop over atoms and neighbors,
   // store edges and _cell_shifts
@@ -398,7 +393,7 @@ void PairAllegro<precision>::compute(int eflag, int vflag){
   // i follows the order of x, f, etc.
   if (debug_mode) printf("Allegro edges: i j rij\n");
 #pragma omp parallel for
-  for(int ii = 0; ii < ntotal; ii++){
+  for (int ii = 0; ii < ntotal; ii++) {
     int i = ilist[ii];
     int itag = tag[i];
     int itype = type[i];
@@ -409,13 +404,13 @@ void PairAllegro<precision>::compute(int eflag, int vflag){
     pos[i][1] = x[i][1];
     pos[i][2] = x[i][2];
 
-    if(ii >= nlocal){continue;}
+    if (ii >= nlocal) { continue; }
 
     int jnum = numneigh[i];
     int *jlist = firstneigh[i];
 
     int edge_counter = cumsum_neigh_per_atom[ii];
-    for(int jj = 0; jj < jnum; jj++){
+    for (int jj = 0; jj < jnum; jj++) {
       int j = jlist[jj];
       j &= NEIGHMASK;
       int jtag = tag[j];
@@ -425,10 +420,11 @@ void PairAllegro<precision>::compute(int eflag, int vflag){
       double dy = x[i][1] - x[j][1];
       double dz = x[i][2] - x[j][2];
 
-      double rsq = dx*dx + dy*dy + dz*dz;
+      double rsq = dx * dx + dy * dy + dz * dz;
 
-      double cutij = cutoff_matrix[itype-1][jtype-1];//cutoff_matrix[(type[i]-1)*ntypes + type[j]-1];
-      if(rsq > cutij*cutij) {continue;}
+      double cutij =
+          cutoff_matrix[itype - 1][jtype - 1];    //cutoff_matrix[(type[i]-1)*ntypes + type[j]-1];
+      if (rsq > cutij * cutij) { continue; }
 
       // TODO: double check order
       edges[0][edge_counter] = i;
@@ -436,15 +432,24 @@ void PairAllegro<precision>::compute(int eflag, int vflag){
 
       edge_counter++;
 
-      if (debug_mode) printf("%d %d %.10g\n", itag-1, jtag-1, sqrt(rsq));
+      if (debug_mode) printf("%d %d %.10g\n", itag - 1, jtag - 1, sqrt(rsq));
     }
   }
   if (debug_mode) printf("end Allegro edges\n");
+
+  torch::Tensor compute_custom_tensor =
+      torch::full({1}, false, torch::TensorOptions().dtype(torch::kBool));
+  if (update->ntimestep == output->next && custom_output_names.size() > 0) {
+    // error->message(FLERR, "computing custom output");
+    auto tmp = compute_custom_tensor.accessor<bool, 1>();
+    tmp[0] = true;
+  }
 
   c10::Dict<std::string, torch::Tensor> input;
   input.insert("pos", pos_tensor.to(device));
   input.insert("edge_index", edges_tensor.to(device));
   input.insert("atom_types", ij2type_tensor.to(device));
+  input.insert("compute_custom_output", compute_custom_tensor);
   std::vector<torch::IValue> input_vector(1, input);
 
   auto output = model.forward(input_vector).toGenericDict();
@@ -465,18 +470,18 @@ void PairAllegro<precision>::compute(int eflag, int vflag){
 
   // Write forces and per-atom energies (0-based tags here)
   eng_vdwl = 0.0;
-#pragma omp parallel for reduction(+:eng_vdwl)
-  for(int ii = 0; ii < ntotal; ii++){
+#pragma omp parallel for reduction(+ : eng_vdwl)
+  for (int ii = 0; ii < ntotal; ii++) {
     int i = ilist[ii];
 
     f[i][0] += forces[i][0];
     f[i][1] += forces[i][1];
     f[i][2] += forces[i][2];
     if (eflag_atom && ii < inum) eatom[i] = atomic_energies[i][0];
-    if(ii < inum) eng_vdwl += atomic_energies[i][0];
+    if (ii < inum) eng_vdwl += atomic_energies[i][0];
   }
 
-  if(vflag){
+  if (vflag) {
     torch::Tensor v_tensor = output.at("virial").toTensor().cpu();
     auto v = v_tensor.accessor<outputtype, 3>();
     // Convert from 3x3 symmetric tensor format, which NequIP outputs, to the flattened form LAMMPS expects
@@ -488,30 +493,31 @@ void PairAllegro<precision>::compute(int eflag, int vflag){
     virial[4] = v[0][0][2];
     virial[5] = v[0][1][2];
   }
-  if(vflag_atom) {
-    error->all(FLERR,"Pair style Allegro does not support per-atom virial");
-  }
+  if (vflag_atom) { error->all(FLERR, "Pair style Allegro does not support per-atom virial"); }
 
-  if (debug_mode) {
-    std::cout << "ALLEGRO CUSTOM OUTPUT" << std::endl;
-    for(const auto &elem : output){
-      std::cout << elem.key() << "\n" << elem.value() << std::endl;
+  if (update->ntimestep == this->output->next) {
+    if (debug_mode) {
+      std::cout << "ALLEGRO CUSTOM OUTPUT" << std::endl;
+      for (const auto &elem : output) {
+        std::cout << elem.key() << "\n" << elem.value() << std::endl;
+      }
     }
-  }
 
-  for(const std::string &output_name : custom_output_names){
-    custom_output.insert_or_assign(output_name, output.at(output_name).toTensor());
+    for (const std::string &output_name : custom_output_names) {
+      if (!output.contains(output_name)) error->all(FLERR, "missing {}", output_name);
+      custom_output.insert_or_assign(output_name, output.at(output_name).toTensor());
+    }
   }
 }
 
-template<Precision precision>
-void PairAllegro<precision>::add_custom_output(std::string name){
+template <Precision precision> void PairAllegro<precision>::add_custom_output(std::string name)
+{
   custom_output_names.push_back(name);
 }
 
 namespace LAMMPS_NS {
-  template class PairAllegro<lowlow>;
-  template class PairAllegro<highhigh>;
-  template class PairAllegro<lowhigh>;
-  template class PairAllegro<highlow>;
-}
+template class PairAllegro<lowlow>;
+template class PairAllegro<highhigh>;
+template class PairAllegro<lowhigh>;
+template class PairAllegro<highlow>;
+}    // namespace LAMMPS_NS

--- a/pair_allegro.cpp
+++ b/pair_allegro.cpp
@@ -240,17 +240,20 @@ void PairAllegro<precision>::coeff(int narg, char **arg) {
   #else
     // In PyTorch >=1.11, this is now set_fusion_strategy
     torch::jit::FusionStrategy strategy;
-    if (metadata["_jit_fusion_strategy"].empty()) {
-      // This is the default used in the Python code
-      strategy = {{torch::jit::FusionBehavior::DYNAMIC, 3}};
-    } else {
-      std::stringstream strat_stream(metadata["_jit_fusion_strategy"]);
-      std::string fusion_type, fusion_depth;
-      while(std::getline(strat_stream, fusion_type, ',')) {
-        std::getline(strat_stream, fusion_depth, ';');
-        strategy.push_back({fusion_type == "STATIC" ? torch::jit::FusionBehavior::STATIC : torch::jit::FusionBehavior::DYNAMIC, std::stoi(fusion_depth)});
-      }
-    }
+    strategy = {{torch::jit::FusionBehavior::DYNAMIC, 10}};
+    //strategy = {{torch::jit::FusionBehavior::STATIC, 100}, {torch::jit::FusionBehavior::DYNAMIC, 1}};
+
+    //if (metadata["_jit_fusion_strategy"].empty()) { //TODO: respect model
+    //  // This is the default used in the Python code
+    //  strategy = {{torch::jit::FusionBehavior::DYNAMIC, 3}};
+    //} else {
+    //  std::stringstream strat_stream(metadata["_jit_fusion_strategy"]);
+    //  std::string fusion_type, fusion_depth;
+    //  while(std::getline(strat_stream, fusion_type, ',')) {
+    //    std::getline(strat_stream, fusion_depth, ';');
+    //    strategy.push_back({fusion_type == "STATIC" ? torch::jit::FusionBehavior::STATIC : torch::jit::FusionBehavior::DYNAMIC, std::stoi(fusion_depth)});
+    //  }
+    //}
     torch::jit::setFusionStrategy(strategy);
   #endif
 

--- a/pair_allegro.cpp
+++ b/pair_allegro.cpp
@@ -122,15 +122,9 @@ PairAllegro<precision>::~PairAllegro(){
 
 template<Precision precision>
 void PairAllegro<precision>::init_style(){
-  if (atom->tag_enable == 0)
-    error->all(FLERR,"Pair style Allegro requires atom IDs");
 
-  // need a full neighbor list
-  int irequest = neighbor->request(this,instance_me);
-  neighbor->requests[irequest]->half = 0;
-  neighbor->requests[irequest]->full = 1;
-
-  neighbor->requests[irequest]->ghost = 1;
+  // Request a full neighbor list.
+  neighbor->add_request(this, NeighConst::REQ_FULL);
 
   if (force->newton_pair == 0)
     error->all(FLERR,"Pair style Allegro requires newton pair on");

--- a/pair_allegro.cpp
+++ b/pair_allegro.cpp
@@ -128,7 +128,7 @@ void PairAllegro<precision>::init_style(){
     error->all(FLERR,"Pair style Allegro requires atom IDs");
 
   // Request a full neighbor list.
-  neighbor->add_request(this, NeighConst::REQ_FULL|NeighConst::REQ_GHOST);
+  neighbor->add_request(this, NeighConst::REQ_FULL);
 
   if (force->newton_pair == 0)
     error->all(FLERR,"Pair style Allegro requires newton pair on");
@@ -369,7 +369,7 @@ void PairAllegro<precision>::compute(int eflag, int vflag){
   int inum = list->inum;
   assert(inum==nlocal); // This should be true, if my understanding is correct
   // Number of ghost atoms
-  int nghost = list->gnum;
+  int nghost = this->atom->nghost;
   // Total number of atoms
   int ntotal = inum + nghost;
   // Mapping from neigh list ordering to x/f ordering

--- a/pair_allegro.cpp
+++ b/pair_allegro.cpp
@@ -126,7 +126,7 @@ void PairAllegro<precision>::init_style(){
     error->all(FLERR,"Pair style Allegro requires atom IDs");
 
   // Request a full neighbor list.
-  neighbor->add_request(this, NeighConst::REQ_FULL);
+  neighbor->add_request(this, NeighConst::REQ_FULL|NeighConst::REQ_GHOST);
 
   if (force->newton_pair == 0)
     error->all(FLERR,"Pair style Allegro requires newton pair on");

--- a/pair_allegro.cpp
+++ b/pair_allegro.cpp
@@ -203,7 +203,7 @@ void PairAllegro<precision>::coeff(int narg, char **arg) {
     model = torch::jit::freeze(model);
   }
 
-  
+
   // In PyTorch >=1.11, this is now set_fusion_strategy
   torch::jit::FusionStrategy strategy;
   strategy = {{torch::jit::FusionBehavior::DYNAMIC, 10}};
@@ -470,9 +470,9 @@ void PairAllegro<precision>::compute(int eflag, int vflag){
   for(int ii = 0; ii < ntotal; ii++){
     int i = ilist[ii];
 
-    f[i][0] = forces[i][0];
-    f[i][1] = forces[i][1];
-    f[i][2] = forces[i][2];
+    f[i][0] += forces[i][0];
+    f[i][1] += forces[i][1];
+    f[i][2] += forces[i][2];
     if (eflag_atom && ii < inum) eatom[i] = atomic_energies[i][0];
     if(ii < inum) eng_vdwl += atomic_energies[i][0];
   }

--- a/pair_allegro.cpp
+++ b/pair_allegro.cpp
@@ -122,6 +122,8 @@ PairAllegro<precision>::~PairAllegro(){
 
 template<Precision precision>
 void PairAllegro<precision>::init_style(){
+  if (atom->tag_enable == 0)
+    error->all(FLERR,"Pair style Allegro requires atom IDs");
 
   // Request a full neighbor list.
   neighbor->add_request(this, NeighConst::REQ_FULL);

--- a/pair_allegro.h
+++ b/pair_allegro.h
@@ -62,6 +62,8 @@ class PairAllegro : public Pair {
  protected:
   int debug_mode = 0;
 
+  double** cutoff_matrix;
+
 };
 
 }

--- a/pair_allegro.h
+++ b/pair_allegro.h
@@ -30,6 +30,9 @@ PairStyle(allegro6432,PairAllegro<highlow>)
 #include <torch/torch.h>
 #include <vector>
 #include <type_traits>
+#include <map>
+#include <string>
+
 enum Precision {lowlow, highhigh, lowhigh, highlow};
 
 namespace LAMMPS_NS {
@@ -58,6 +61,10 @@ class PairAllegro : public Pair {
 
   torch::ScalarType inputtorchtype = torch::CppTypeToScalarType<inputtype>();
   torch::ScalarType outputtorchtype = torch::CppTypeToScalarType<outputtype>();
+
+  std::vector<std::string> custom_output_names;
+  std::map<std::string, torch::Tensor> custom_output;
+  void add_custom_output(std::string);
 
  protected:
   int debug_mode = 0;

--- a/pair_allegro_kokkos.cpp
+++ b/pair_allegro_kokkos.cpp
@@ -348,7 +348,7 @@ void PairAllegroKokkos<precision>::compute(int eflag_in, int vflag_in)
   if (this->vflag_fdotr) pair_virial_fdotr_compute(this);
 
   for(const std::string &output_name : this->custom_output_names){
-    this->custom_output.insert_or_assign(output_name, output.at(output_name).toTensor());
+    this->custom_output.insert_or_assign(output_name, output.at(output_name).toTensor().detach());
   }
 
 

--- a/pair_allegro_kokkos.cpp
+++ b/pair_allegro_kokkos.cpp
@@ -33,7 +33,10 @@
 #include <pair_allegro_kokkos.h>
 #include <torch/torch.h>
 #include <torch/script.h>
+
+#ifdef KOKKOS_ENABLE_CUDA
 #include <c10/cuda/CUDACachingAllocator.h>
+#endif
 
 using namespace LAMMPS_NS;
 using namespace MathConst;
@@ -343,6 +346,11 @@ void PairAllegroKokkos<precision>::compute(int eflag_in, int vflag_in)
   }
 
   if (this->vflag_fdotr) pair_virial_fdotr_compute(this);
+
+  for(const std::string &output_name : this->custom_output_names){
+    this->custom_output.insert_or_assign(output_name, output.at(output_name).toTensor());
+  }
+
 
   this->copymode = 0;
 

--- a/pair_allegro_kokkos.cpp
+++ b/pair_allegro_kokkos.cpp
@@ -306,9 +306,9 @@ void PairAllegroKokkos<precision>::compute(int eflag_in, int vflag_in)
   Kokkos::parallel_reduce("Allegro: store forces",
       Kokkos::RangePolicy<DeviceType>(0, ignum),
       KOKKOS_LAMBDA(const int i, double &eng_vdwl){
-        f(i,0) = d_forces(i,0);
-        f(i,1) = d_forces(i,1);
-        f(i,2) = d_forces(i,2);
+        f(i,0) += d_forces(i,0);
+        f(i,1) += d_forces(i,1);
+        f(i,2) += d_forces(i,2);
         if(eflag_atom && i < inum){
           d_eatom(i) = d_atomic_energy(i);
         }

--- a/pair_allegro_kokkos.cpp
+++ b/pair_allegro_kokkos.cpp
@@ -354,28 +354,15 @@ void PairAllegroKokkos<precision>::init_style()
 {
   super::init_style();
 
-  // irequest = neigh request made by parent class
+  auto request = this->neighbor->find_request(this);
+  request->set_kokkos_host(std::is_same<DeviceType,LMPHostType>::value &&
+      !std::is_same<DeviceType,LMPDeviceType>::value);
+  request->set_kokkos_device(std::is_same<DeviceType,LMPDeviceType>::value);
 
   neighflag = this->lmp->kokkos->neighflag;
-  int irequest = this->neighbor->nrequest - 1;
-
-  this->neighbor->requests[irequest]->
-    kokkos_host = std::is_same<DeviceType,LMPHostType>::value &&
-    !std::is_same<DeviceType,LMPDeviceType>::value;
-  this->neighbor->requests[irequest]->
-    kokkos_device = std::is_same<DeviceType,LMPDeviceType>::value;
-
-  // always request a full neighbor list
-
-  if (neighflag == FULL) { // TODO: figure this out
-    this->neighbor->requests[irequest]->full = 1;
-    this->neighbor->requests[irequest]->half = 0;
-    this->neighbor->requests[irequest]->ghost = 1;
-  } else {
-    this->error->all(FLERR,"Cannot use chosen neighbor list style with pair_allegro/kk");
+  if (neighflag != FULL) {
+    this->error->all(FLERR,"Needs full neighbor list style with pair_allegro/kk");
   }
-  if (this->force->newton_pair == 0)
-    this->error->all(FLERR,"Pair style Allegro requires newton pair on");
 }
 
 

--- a/pair_allegro_kokkos.cpp
+++ b/pair_allegro_kokkos.cpp
@@ -116,7 +116,7 @@ void PairAllegroKokkos<precision>::compute(int eflag_in, int vflag_in)
   nall = this->atom->nlocal + this->atom->nghost;
 
   const int inum = this->list->inum;
-  const int ignum = inum + this->list->gnum;
+  const int ignum = inum + this->atom->nghost;
   NeighListKokkos<DeviceType>* k_list = static_cast<NeighListKokkos<DeviceType>*>(this->list);
   d_ilist = k_list->d_ilist;
   d_numneigh = k_list->d_numneigh;

--- a/pair_allegro_kokkos.cpp
+++ b/pair_allegro_kokkos.cpp
@@ -121,6 +121,8 @@ void PairAllegroKokkos<precision>::compute(int eflag_in, int vflag_in)
   d_numneigh = k_list->d_numneigh;
   d_neighbors = k_list->d_neighbors;
 
+  if (inum==0) return; // empty domain
+
   this->copymode = 1;
 
 

--- a/pair_allegro_kokkos.h
+++ b/pair_allegro_kokkos.h
@@ -13,7 +13,7 @@
 
 #ifdef PAIR_CLASS
 
-PairStyle(allegro/kk,PairAllegroKokkos<lowlow>)
+PairStyle(allegro/kk,PairAllegroKokkos<lowhigh>)
 PairStyle(allegro3232/kk,PairAllegroKokkos<lowlow>)
 PairStyle(allegro6464/kk,PairAllegroKokkos<highhigh>)
 PairStyle(allegro3264/kk,PairAllegroKokkos<lowhigh>)

--- a/pair_allegro_kokkos.h
+++ b/pair_allegro_kokkos.h
@@ -96,6 +96,8 @@ class PairAllegroKokkos : public PairAllegro<precision> {
   LongView2D d_edges;
   InputFloatView2D d_xfloat;
 
+  View2D d_cutoff_matrix;
+
 
 
   typename AT::t_neighbors_2d d_neighbors;

--- a/patch_lammps.sh
+++ b/patch_lammps.sh
@@ -68,6 +68,8 @@ fi
 
 echo "Updating CMakeLists.txt..."
 
+sed -i "s/set(CMAKE_CXX_STANDARD 11)/set(CMAKE_CXX_STANDARD 14)/" $lammps_dir/cmake/CMakeLists.txt
+
 # Add libtorch
 cat >> $lammps_dir/cmake/CMakeLists.txt << "EOF2"
 

--- a/patch_lammps.sh
+++ b/patch_lammps.sh
@@ -69,7 +69,7 @@ fi
 echo "Updating CMakeLists.txt..."
 
 # Update CMakeLists.txt
-sed -i "s/set(CMAKE_CXX_STANDARD 1.)/set(CMAKE_CXX_STANDARD 17)/" $lammps_dir/cmake/CMakeLists.txt
+sed -i "s/set(CMAKE_CXX_STANDARD 1.)/set(CMAKE_CXX_STANDARD 14)/" $lammps_dir/cmake/CMakeLists.txt
 
 # Add libtorch
 cat >> $lammps_dir/cmake/CMakeLists.txt << "EOF2"

--- a/patch_lammps.sh
+++ b/patch_lammps.sh
@@ -68,7 +68,7 @@ fi
 
 echo "Updating CMakeLists.txt..."
 
-sed -i "s/set(CMAKE_CXX_STANDARD 11)/set(CMAKE_CXX_STANDARD 14)/" $lammps_dir/cmake/CMakeLists.txt
+sed -i "s/set(CMAKE_CXX_STANDARD 11)/set(CMAKE_CXX_STANDARD 17)/" $lammps_dir/cmake/CMakeLists.txt
 
 # Add libtorch
 cat >> $lammps_dir/cmake/CMakeLists.txt << "EOF2"

--- a/patch_lammps.sh
+++ b/patch_lammps.sh
@@ -50,18 +50,18 @@ fi
 if [ "$do_e_mode" = true ]
 then
     echo "Making source symlinks (-e)..."
-    for file in pair_allegro.*; do
+    for file in *_allegro.*; do
         ln -s `realpath -s $file` $lammps_dir/src/$file
     done
-    for file in pair_allegro_kokkos.*; do
+    for file in *_allegro_kokkos.*; do
         ln -s `realpath -s $file` $lammps_dir/src/KOKKOS/$file
     done
 else
     echo "Copying files..."
-    for file in pair_allegro.*; do
+    for file in *_allegro.*; do
         cp $file $lammps_dir/src/$file
     done
-    for file in pair_allegro_kokkos.*; do
+    for file in *_allegro_kokkos.*; do
         cp $file $lammps_dir/src/KOKKOS/$file
     done
 fi

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,16 @@ from nequip.data import dataset_from_config
 
 TESTS_DIR = Path(__file__).resolve().parent
 LAMMPS = os.environ.get("LAMMPS", "lmp")
-_lmp_help = subprocess.run([LAMMPS, "-h"], stdout=subprocess.PIPE, check=True).stdout
+# Allow user to specify prefix to set up environment before mpirun. For example,
+# using `LAMMPS_ENV_PREFIX="conda run -n whatever"` to run LAMMPS in a different
+# conda environment.
+LAMMPS_ENV_PREFIX = os.environ.get("LAMMPS_ENV_PREFIX", "")
+_lmp_help = subprocess.run(
+    " ".join([LAMMPS_ENV_PREFIX, "mpirun", LAMMPS, "-h"]),
+    shell="True",
+    stdout=subprocess.PIPE,
+    check=True,
+).stdout
 HAS_KOKKOS: bool = b"allegro/kk" in _lmp_help
 HAS_KOKKOS_CUDA: bool = b"KOKKOS package API: CUDA" in _lmp_help
 HAS_OPENMP: bool = b"OPENMP" in _lmp_help

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,129 @@
+import pytest
+
+import os
+import sys
+import tempfile
+import subprocess
+from pathlib import Path
+import numpy as np
+import yaml
+import warnings
+
+import torch
+
+from nequip.utils import Config
+from nequip.data import dataset_from_config
+
+TESTS_DIR = Path(__file__).resolve().parent
+LAMMPS = os.environ.get("LAMMPS", "lmp")
+_lmp_help = subprocess.run([LAMMPS, "-h"], stdout=subprocess.PIPE, check=True).stdout
+HAS_KOKKOS: bool = b"allegro/kk" in _lmp_help
+HAS_KOKKOS_CUDA: bool = b"KOKKOS package API: CUDA" in _lmp_help
+HAS_OPENMP: bool = b"OPENMP" in _lmp_help
+
+if not HAS_KOKKOS:
+    warnings.warn("Not testing pair_allegro with Kokkos since it wasn't built with it")
+if HAS_KOKKOS and torch.cuda.is_available() and not HAS_KOKKOS_CUDA:
+    warnings.warn("Kokkos not built with CUDA even though CUDA is available")
+if not HAS_OPENMP:
+    warnings.warn(
+        "Not testing pair_allegro with OpenMP since LAMMPS wasn't built with the OPENMP package"
+    )
+
+
+@pytest.fixture(
+    # params=[
+    #     ("CuPd-cubic-big.xyz", "CuPd", ["Cu", "Pd"], 5.1, n_rank)
+    #     for n_rank in (1, 2, 4)
+    # ]
+    # + [
+    params=[
+        ("aspirin.xyz", "aspirin", ["C", "H", "O"], 4.0, 1),
+        ("aspirin.xyz", "aspirin", ["C", "H", "O"], 15.0, 1),
+        ("Cu2AgO4.xyz", "mp-1225882", ["Cu", "Ag", "O"], 4.9, 1),
+        ("Cu-cubic.xyz", "Cu", ["Cu"], 4.5, 1),
+        ("Cu-cubic.xyz", "Cu", ["Cu"], 15.5, 1),
+    ],
+    scope="session",
+)
+def dataset_options(request):
+    out = dict(
+        zip(
+            ["dataset_file_name", "run_name", "chemical_symbols", "r_max"],
+            request.param,
+        )
+    )
+    out["dataset_file_name"] = TESTS_DIR / ("test_data/" + out["dataset_file_name"])
+    return out, request.param[-1]
+
+
+@pytest.fixture(
+    params=[
+        187382,
+        109109,
+    ],
+    scope="session",
+)
+def model_seed(request):
+    return request.param
+
+
+def _check_and_print(retcode):
+    __tracebackhide__ = True
+    if retcode.returncode:
+        if len(retcode.stdout) > 0:
+            print(retcode.stdout.decode("ascii"))
+        if len(retcode.stderr) > 0:
+            print(retcode.stderr.decode("ascii"), file=sys.stderr)
+        retcode.check_returncode()
+
+
+@pytest.fixture(scope="session")
+def deployed_model(model_seed, dataset_options):
+    dataset_options, n_rank = dataset_options
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config = Config.from_file(str(TESTS_DIR / "test_data/test_repro.yaml"))
+        config.update(dataset_options)
+        config["seed"] = model_seed
+        config["root"] = tmpdir + "/root"
+        configpath = tmpdir + "/config.yaml"
+        with open(configpath, "w") as f:
+            yaml.dump(dict(config), f)
+        # run a nequip-train command
+        retcode = subprocess.run(
+            ["nequip-train", configpath],
+            cwd=tmpdir,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        _check_and_print(retcode)
+        # run nequip-deploy
+        deployed_path = tmpdir + "/deployed.pth"
+        retcode = subprocess.run(
+            [
+                "nequip-deploy",
+                "build",
+                "--train-dir",
+                config["root"] + "/" + config["run_name"],
+                deployed_path,
+            ],
+            cwd=tmpdir,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        _check_and_print(retcode)
+        # load structures to test on
+        d = dataset_from_config(config)
+        # take some frames
+        structures = [d[i].to_ase(type_mapper=d.type_mapper) for i in range(5)]
+        # give them cells even if nonperiodic
+        if not all(structures[0].pbc):
+            L = 50.0
+            for struct in structures:
+                struct.cell = L * np.eye(3)
+                struct.center()
+        for s in structures:
+            s.rattle(stdev=0.2)
+            s.wrap()
+        structures = structures[:1]
+        yield deployed_path, structures, config, n_rank

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,16 +32,15 @@ if not HAS_OPENMP:
 
 
 @pytest.fixture(
-    # params=[
-    #     ("CuPd-cubic-big.xyz", "CuPd", ["Cu", "Pd"], 5.1, n_rank)
-    #     for n_rank in (1, 2, 4)
-    # ]
-    # + [
     params=[
+        ("CuPd-cubic-big.xyz", "CuPd", ["Cu", "Pd"], 5.1, n_rank)
+        for n_rank in (1, 4, 8)
+    ]
+    + [("Cu-cubic.xyz", "Cu", ["Cu"], 4.5, n_rank) for n_rank in (1, 2)]
+    + [
         ("aspirin.xyz", "aspirin", ["C", "H", "O"], 4.0, 1),
         ("aspirin.xyz", "aspirin", ["C", "H", "O"], 15.0, 1),
         ("Cu2AgO4.xyz", "mp-1225882", ["Cu", "Ag", "O"], 4.9, 1),
-        ("Cu-cubic.xyz", "Cu", ["Cu"], 4.5, 1),
         ("Cu-cubic.xyz", "Cu", ["Cu"], 15.5, 1),
     ],
     scope="session",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,7 +47,7 @@ if not HAS_OPENMP:
     ]
     + [("Cu-cubic.xyz", "Cu", ["Cu"], 4.5, n_rank) for n_rank in (1, 2)]
     + [
-        ("aspirin.xyz", "aspirin", ["C", "H", "O"], 4.0, 1),
+        ("aspirin.xyz", "aspirin", ["C", "H", "O"], 4.444, 1),
         ("aspirin.xyz", "aspirin", ["C", "H", "O"], 15.0, 1),
         ("Cu2AgO4.xyz", "mp-1225882", ["Cu", "Ag", "O"], 4.9, 1),
         ("Cu-cubic.xyz", "Cu", ["Cu"], 15.5, 1),

--- a/tests/test_data/test_repro.yaml
+++ b/tests/test_data/test_repro.yaml
@@ -5,7 +5,7 @@ dataset_seed: 456
 model_builders:
  - allegro.model.Allegro
  - PerSpeciesRescale
- - ForceOutput
+ - StressForceOutput
  - RescaleEnergyEtc
 
 avg_num_neighbors: auto

--- a/tests/test_data/test_repro.yaml
+++ b/tests/test_data/test_repro.yaml
@@ -2,6 +2,10 @@ run_name: minimal
 seed: 123
 dataset_seed: 456
 
+default_dtype: float64
+model_dtype: float32
+allow_tf32: false
+
 model_builders:
  - allegro.model.Allegro
  - PerSpeciesRescale
@@ -15,8 +19,6 @@ parity: o3_full
 # Allegro layers:
 num_layers: 2
 env_embed_multiplicity: 8
-embed_initial_edge: true
-linear_after_env_embed: false
 
 two_body_latent_mlp_latent_dimensions: [32, 32]
 two_body_latent_mlp_nonlinearity: silu
@@ -25,7 +27,6 @@ two_body_latent_mlp_initialization: uniform
 latent_mlp_latent_dimensions: [32]
 latent_mlp_nonlinearity: silu
 latent_mlp_initialization: uniform
-latent_resnet: true
 
 env_embed_mlp_latent_dimensions: []
 env_embed_mlp_nonlinearity: null

--- a/tests/test_data/test_repro.yaml
+++ b/tests/test_data/test_repro.yaml
@@ -20,23 +20,23 @@ parity: o3_full
 num_layers: 2
 env_embed_multiplicity: 8
 
-two_body_latent_mlp_latent_dimensions: [32, 32]
+two_body_latent_mlp_latent_dimensions: [64, 64]
 two_body_latent_mlp_nonlinearity: silu
-two_body_latent_mlp_initialization: uniform
+two_body_latent_mlp_initialization: normal  # normal is closer to a trained weight distribution for numerics
 
-latent_mlp_latent_dimensions: [32]
+latent_mlp_latent_dimensions: [64, 64]
 latent_mlp_nonlinearity: silu
-latent_mlp_initialization: uniform
+latent_mlp_initialization: normal
 
 env_embed_mlp_latent_dimensions: []
 env_embed_mlp_nonlinearity: null
-env_embed_mlp_initialization: uniform
+env_embed_mlp_initialization: normal
 # - end allegro layers -
 
 # Final MLP to go from Allegro latent space to edge energies:
-edge_eng_mlp_latent_dimensions: [8]
+edge_eng_mlp_latent_dimensions: [32]
 edge_eng_mlp_nonlinearity: null
-edge_eng_mlp_initialization: uniform
+edge_eng_mlp_initialization: normal
 
 dataset: ase
 dataset_file_name: aspirin.xyz

--- a/tests/test_data/test_repro.yaml
+++ b/tests/test_data/test_repro.yaml
@@ -34,7 +34,7 @@ env_embed_mlp_initialization: normal
 # - end allegro layers -
 
 # Final MLP to go from Allegro latent space to edge energies:
-edge_eng_mlp_latent_dimensions: [32]
+edge_eng_mlp_latent_dimensions: [64]
 edge_eng_mlp_nonlinearity: null
 edge_eng_mlp_initialization: normal
 

--- a/tests/test_python_repro.py
+++ b/tests/test_python_repro.py
@@ -1,14 +1,11 @@
 import pytest
 
 import os
-import sys
 import tempfile
 import subprocess
 from pathlib import Path
 import numpy as np
-import yaml
 import textwrap
-import warnings
 from io import StringIO
 from collections import Counter
 
@@ -19,118 +16,9 @@ import ase.io
 import torch
 
 from nequip.ase import NequIPCalculator
-from nequip.utils import Config
-from nequip.data import dataset_from_config, AtomicData, AtomicDataDict
+from nequip.data import AtomicData, AtomicDataDict
 
-TESTS_DIR = Path(__file__).resolve().parent
-LAMMPS = os.environ.get("LAMMPS", "lmp")
-_lmp_help = subprocess.run([LAMMPS, "-h"], stdout=subprocess.PIPE, check=True).stdout
-HAS_KOKKOS: bool = b"allegro/kk" in _lmp_help
-HAS_OPENMP: bool = b"OPENMP" in _lmp_help
-
-if not HAS_KOKKOS:
-    warnings.warn("Not testing pair_allegro with Kokkos since it wasn't built with it")
-if not HAS_OPENMP:
-    warnings.warn(
-        "Not testing pair_allegro with OpenMP since LAMMPS wasn't built with the OPENMP package"
-    )
-
-
-@pytest.fixture(
-    params=[
-        ("CuPd-cubic-big.xyz", "CuPd", ["Cu", "Pd"], 5.1, n_rank)
-        for n_rank in (1, 2, 4)
-    ]
-    + [
-        ("aspirin.xyz", "aspirin", ["C", "H", "O"], 4.0, 1),
-        ("aspirin.xyz", "aspirin", ["C", "H", "O"], 15.0, 1),
-        ("Cu2AgO4.xyz", "mp-1225882", ["Cu", "Ag", "O"], 4.9, 1),
-        ("Cu-cubic.xyz", "Cu", ["Cu"], 4.5, 1),
-        ("Cu-cubic.xyz", "Cu", ["Cu"], 15.5, 1),
-    ],
-    scope="module",
-)
-def dataset_options(request):
-    out = dict(
-        zip(
-            ["dataset_file_name", "run_name", "chemical_symbols", "r_max"],
-            request.param,
-        )
-    )
-    out["dataset_file_name"] = TESTS_DIR / ("test_data/" + out["dataset_file_name"])
-    return out, request.param[-1]
-
-
-@pytest.fixture(
-    params=[
-        187382,
-        109109,
-    ],
-    scope="module",
-)
-def model_seed(request):
-    return request.param
-
-
-def _check_and_print(retcode):
-    __tracebackhide__ = True
-    if retcode.returncode:
-        if len(retcode.stdout) > 0:
-            print(retcode.stdout.decode("ascii"))
-        if len(retcode.stderr) > 0:
-            print(retcode.stderr.decode("ascii"), file=sys.stderr)
-        retcode.check_returncode()
-
-
-@pytest.fixture(scope="module")
-def deployed_model(model_seed, dataset_options):
-    dataset_options, n_rank = dataset_options
-    with tempfile.TemporaryDirectory() as tmpdir:
-        config = Config.from_file(str(TESTS_DIR / "test_data/test_repro.yaml"))
-        config.update(dataset_options)
-        config["seed"] = model_seed
-        config["root"] = tmpdir + "/root"
-        configpath = tmpdir + "/config.yaml"
-        with open(configpath, "w") as f:
-            yaml.dump(dict(config), f)
-        # run a nequip-train command
-        retcode = subprocess.run(
-            ["nequip-train", configpath],
-            cwd=tmpdir,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
-        _check_and_print(retcode)
-        # run nequip-deploy
-        deployed_path = tmpdir + "/deployed.pth"
-        retcode = subprocess.run(
-            [
-                "nequip-deploy",
-                "build",
-                "--train-dir",
-                config["root"] + "/" + config["run_name"],
-                deployed_path,
-            ],
-            cwd=tmpdir,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
-        _check_and_print(retcode)
-        # load structures to test on
-        d = dataset_from_config(config)
-        # take some frames
-        structures = [d[i].to_ase(type_mapper=d.type_mapper) for i in range(5)]
-        # give them cells even if nonperiodic
-        if not all(structures[0].pbc):
-            L = 50.0
-            for struct in structures:
-                struct.cell = L * np.eye(3)
-                struct.center()
-        for s in structures:
-            s.rattle(stdev=0.2)
-            s.wrap()
-        structures = structures[:1]
-        yield deployed_path, structures, config, n_rank
+from conftest import _check_and_print, LAMMPS, HAS_KOKKOS, HAS_KOKKOS_CUDA, HAS_OPENMP
 
 
 @pytest.mark.parametrize(
@@ -230,10 +118,10 @@ def test_repro(deployed_model, kokkos: bool, openmp: bool):
                         "kk",
                         "-k",
                         "on",
-                        ("g" if torch.cuda.is_available() else "t"),
+                        ("g" if HAS_KOKKOS_CUDA else "t"),
                         str(
                             max(torch.cuda.device_count() // n_rank, 1)
-                            if torch.cuda.is_available()
+                            if HAS_KOKKOS_CUDA
                             else OMP_NUM_THREADS
                         ),
                         "-pk",

--- a/tests/test_python_repro.py
+++ b/tests/test_python_repro.py
@@ -146,7 +146,7 @@ def test_repro(deployed_model, kokkos: bool, openmp: bool):
                     )
                     # input
                     + ["-in", infile_path]
-                ).join(" "),
+                ),
                 cwd=tmpdir,
                 env=env,
                 stdout=subprocess.PIPE,

--- a/tests/test_python_repro.py
+++ b/tests/test_python_repro.py
@@ -212,7 +212,15 @@ def test_repro(deployed_model, kokkos: bool, openmp: bool):
             OMP_NUM_THREADS = 4  # just some choice
             retcode = subprocess.run(
                 # MPI options if MPI
-                (["mpirun", "-np", str(n_rank)] if n_rank > 1 else [])
+                # --oversubscribe necessary for GitHub Actions since it only gives 2 slots
+                # > Alternatively, you can use the --oversubscribe option to ignore the
+                # > number of available slots when deciding the number of processes to
+                # > launch.
+                (
+                    ["mpirun", "--oversubscribe", "-np", str(n_rank)]
+                    if n_rank > 1
+                    else []
+                )
                 # LAMMPS exec
                 + [LAMMPS]
                 # Kokkos options if Kokkos

--- a/tests/test_python_repro.py
+++ b/tests/test_python_repro.py
@@ -69,9 +69,11 @@ def test_repro(deployed_model, kokkos: bool, openmp: bool):
 
         compute atomicenergies all pe/atom
         compute totalatomicenergy all reduce sum c_atomicenergies
+        compute stress all pressure NULL virial  # NULL means without temperature contribution
 
-        thermo_style custom step time temp pe c_totalatomicenergy etotal press spcpu cpuremain
+        thermo_style custom step time temp pe c_totalatomicenergy etotal press spcpu cpuremain c_stress[*]
         run 0
+        print "$({PRECISION_CONST} * c_stress[1]) $({PRECISION_CONST} * c_stress[2]) $({PRECISION_CONST} * c_stress[3]) $({PRECISION_CONST} * c_stress[4]) $({PRECISION_CONST} * c_stress[5]) $({PRECISION_CONST} * c_stress[6])" file stress.dat
         print $({PRECISION_CONST} * pe) file pe.dat
         print $({PRECISION_CONST} * c_totalatomicenergy) file totalatomicenergy.dat
         write_dump all custom output.dump id type x y z fx fy fz c_atomicenergies modify format float %20.15g
@@ -272,3 +274,27 @@ def test_repro(deployed_model, kokkos: bool, openmp: bool):
                 lammps_pe,
                 atol=1e-6,
             )
+            # in `metal` units, pressure/stress has units bars
+            # so need to convert
+            lammps_stress = np.fromstring(
+                Path(tmpdir + f"/stress.dat").read_text(), sep=" ", dtype=np.float64
+            ) * (ase.units.bar / PRECISION_CONST)
+            # https://docs.lammps.org/compute_pressure.html
+            # > The ordering of values in the symmetric pressure tensor is as follows: pxx, pyy, pzz, pxy, pxz, pyz.
+            lammps_stress = np.array(
+                [
+                    [lammps_stress[0], lammps_stress[3], lammps_stress[4]],
+                    [lammps_stress[3], lammps_stress[1], lammps_stress[5]],
+                    [lammps_stress[4], lammps_stress[5], lammps_stress[2]],
+                ]
+            )
+            if periodic:
+                # In LAMMPS, the convention is that the stress tensor, and thus the pressure, is related to the virial
+                # WITHOUT a sign change.  In `nequip`, we chose currently to follow the virial = -stress x volume
+                # convention => stress = -1/V * virial.  ASE does not change the sign of the virial, so we have
+                # to flip the sign from ASE for the comparison.
+                assert np.allclose(
+                    -structure.get_stress(voigt=False),
+                    lammps_stress,
+                    atol=1e-5,
+                )

--- a/tests/test_python_repro.py
+++ b/tests/test_python_repro.py
@@ -18,7 +18,14 @@ import torch
 from nequip.ase import NequIPCalculator
 from nequip.data import AtomicData, AtomicDataDict
 
-from conftest import _check_and_print, LAMMPS, HAS_KOKKOS, HAS_KOKKOS_CUDA, HAS_OPENMP
+from conftest import (
+    _check_and_print,
+    LAMMPS,
+    LAMMPS_ENV_PREFIX,
+    HAS_KOKKOS,
+    HAS_KOKKOS_CUDA,
+    HAS_OPENMP,
+)
 
 
 @pytest.mark.parametrize(
@@ -105,20 +112,14 @@ def test_repro(deployed_model, kokkos: bool, openmp: bool):
                     # Allow user to specify prefix to set up environment before mpirun. For example,
                     # using `LAMMPS_ENV_PREFIX="conda run -n whatever"` to run LAMMPS in a different
                     # conda environment.
-                    [os.environ.get("LAMMPS_ENV_PREFIX", "")]
+                    [LAMMPS_ENV_PREFIX]
                     +
                     # MPI options if MPI
                     # --oversubscribe necessary for GitHub Actions since it only gives 2 slots
                     # > Alternatively, you can use the --oversubscribe option to ignore the
                     # > number of available slots when deciding the number of processes to
                     # > launch.
-                    (
-                        ["mpirun", "--oversubscribe", "-np", str(n_rank)]
-                        if n_rank > 1
-                        else []
-                    )
-                    # LAMMPS exec
-                    + [LAMMPS]
+                    ["mpirun", "--oversubscribe", "-np", str(n_rank), LAMMPS]
                     # Kokkos options if Kokkos
                     + (
                         [


### PR DESCRIPTION
Update main to remove the mess of stress/multicut/compute.

This includes:
- Adding precision support (default is 3264).
- Add support for cutoff matrix.
- Add padding by 5% to the Kokkos version for more consistent performance, see fig. 5 of [bio paper](https://arxiv.org/abs/2304.10061).
- Adding stress support. Requires models to be built with `StressForceOutput`.
- Adding the compute for custom output, both global and per-atom. Documented in README.

Unfortunately, linting happened for pair_allegro.cpp. I don't like the end result, but oh well.